### PR TITLE
多人数作業用にトークン・サーバーIDをコマンドラインからも入力できるように調整など

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+/package-lock.json
+/package.json
+/node_modules
+/__pycache__
+/cogs/__pycache__
+/.env

--- a/Monokubs.py
+++ b/Monokubs.py
@@ -1,15 +1,27 @@
 import os
 import collections
 import dataclasses
-from dotenv import load_dotenv
 from typing import List, Literal
 import discord
 from discord.ext import commands
 import gv 
+import sys
 
-load_dotenv()#環境変数の読み込み
+guildId : str
+tokenId : str
 
-Test_GUILD = discord.Object(id=os.getenv("GUILD_ID"))#テスト鯖のIDからテスト鯖オブジェクトを取得
+# 引数解析
+args = sys.argv
+for arg in args:
+    # -delPriv でstart時にこのbotから見えている１：１対話用チャンネルを消す
+    if '=' in arg:
+        sentences = arg.split('=')
+        if ('-guildId' in sentences[0]):
+            guildId = str(sentences[1])
+        if ('-tokenId' in sentences[0]):
+            tokenId = str(sentences[1])
+
+Test_GUILD = discord.Object(id=guildId)#テスト鯖のIDからテスト鯖オブジェクトを取得
 
 #キャラの役職パラメータと役職名の変換辞書
 role_para_to_name:dict = {
@@ -55,12 +67,14 @@ initial_extensions = [
 ]
 #botのインスタンス化と起動時の処理
 class MonokubsBot(commands.Bot):
-    def __init__(self):
+    useGuildId : str
+
+    def __init__(self, guildId):
         super().__init__(
             command_prefix=commands.when_mentioned_or('!'),# メンション若しくは!でコマンドを認識する　あんまり使わないけど
             intents=discord.Intents.all()# すべてのインテント権限をTureにする
             )
-
+        self.useGuildId = guildId
 
     # セットアップ時の処理
     async def setup_hook(self) -> None:
@@ -88,7 +102,7 @@ class MonokubsBot(commands.Bot):
         print(f'Logged in as {self.user} (ID: {self.user.id})')#ログインしたやでとターミナルに出力
         print('------')
 
-bot = MonokubsBot()
+bot = MonokubsBot(guildId)
 
 #自動リネーム機能　及び　ロール付与に反応するやつ全般　最終的に死亡時処理だけになりそう
 @bot.event 
@@ -532,4 +546,4 @@ async def ext_reload(
         print(e)
     await itx.response.send_message(f"{ext_name}のリロードが完了しました",ephemeral=True)
 
-bot.run(os.getenv("TOKEN"))
+bot.run(tokenId)

--- a/Monokubs.py
+++ b/Monokubs.py
@@ -1,27 +1,36 @@
 import os
+import sys
 import collections
 import dataclasses
+from dotenv import load_dotenv
 from typing import List, Literal
 import discord
 from discord.ext import commands
 import gv 
-import sys
 
 guildId : str
 tokenId : str
 
+#環境変数の読み込み
+if os.path.isfile('.env'):
+    load_dotenv()
+    print('.envファイルからトークン・サーバー情報を読み込みます')
+    guildId=os.getenv("GUILD_ID")
+    tokenId=os.getenv("TOKEN")
+
 # 引数解析
 args = sys.argv
 for arg in args:
-    # -delPriv でstart時にこのbotから見えている１：１対話用チャンネルを消す
     if '=' in arg:
         sentences = arg.split('=')
         if ('-guildId' in sentences[0]):
+            print('コマンドラインオプションによりGuildIdを設定')
             guildId = str(sentences[1])
         if ('-tokenId' in sentences[0]):
+            print('コマンドラインオプションによりTokenIdを設定')
             tokenId = str(sentences[1])
 
-Test_GUILD = discord.Object(id=guildId)#テスト鯖のIDからテスト鯖オブジェクトを取得
+Test_GUILD = discord.Object(id=guildId)
 
 #キャラの役職パラメータと役職名の変換辞書
 role_para_to_name:dict = {

--- a/[env]pythonの必要なパッケージをインストール.bat
+++ b/[env]pythonの必要なパッケージをインストール.bat
@@ -1,0 +1,16 @@
+@echo off
+setlocal
+
+pushd
+
+:: 手元のスクリプトに必要なライブラリをpipでまとめてインストール
+
+set pipcmd=pip install -r requirements.txt
+echo %pipcmd%
+title %pipcmd%
+call %pipcmd%
+echo;
+
+popd
+
+exit /b

--- a/cogs/Add_dead_role.py
+++ b/cogs/Add_dead_role.py
@@ -1,5 +1,4 @@
 import os 
-from dotenv import load_dotenv
 
 from typing import List, Literal
 
@@ -10,7 +9,6 @@ from discord.ext import commands
 
 import gv
 
-load_dotenv()
 
 class Add_dead_role(commands.Cog):#Cog名、任意だが分かりやすさのためにコマンドが一つなら頭大文字でクラス作成
     def __init__(self, bot:commands.Bot):
@@ -36,5 +34,5 @@ class Add_dead_role(commands.Cog):#Cog名、任意だが分かりやすさのた
 async def setup(bot:commands.Bot):
     await bot.add_cog(
         Add_dead_role(bot),
-        guilds = [discord.Object(id=os.getenv("GUILD_ID"))]
+        guilds = [discord.Object(id=bot.useGuildId)]
         )

--- a/cogs/Album.py
+++ b/cogs/Album.py
@@ -1,13 +1,11 @@
 import os 
 import discord.context_managers
-from dotenv import load_dotenv
 
 import discord
 from discord import app_commands
 from discord.ext import commands
 import gv
 
-load_dotenv()
 
 class Album_Select(discord.ui.Select):
     def __init__(self,options:list[discord.SelectOption]):
@@ -53,5 +51,5 @@ class Album(commands.Cog):#Cog名、頭大文字でクラス作成
 async def setup(bot:commands.Bot):
     await bot.add_cog(
         Album(bot),
-        guilds = [discord.Object(id=os.getenv("GUILD_ID"))]
+        guilds = [discord.Object(id=bot.useGuildId)]
         )

--- a/cogs/CardList.py
+++ b/cogs/CardList.py
@@ -6,7 +6,6 @@ from discord import app_commands
 from discord.ext import commands
 from discord.ext.ui import View,ViewTracker, MessageProvider,PageView,PaginationView,Message
 
-load_dotenv()
 #試作中　動かないよ！
 
 

--- a/cogs/CardList.py
+++ b/cogs/CardList.py
@@ -1,6 +1,5 @@
 import os 
 import discord.context_managers
-from dotenv import load_dotenv
 
 import discord
 from discord import app_commands
@@ -44,5 +43,5 @@ class CardList(commands.Cog):
 async def setup(bot:commands.Bot):
     await bot.add_cog(
         CardList(bot),
-        guilds = [discord.Object(id=os.getenv("GUILD_ID"))]
+        guilds = [discord.Object(id=bot.useGuildId)]
         )

--- a/cogs/Hagakure_ability.py
+++ b/cogs/Hagakure_ability.py
@@ -1,13 +1,11 @@
 import os 
 import discord.context_managers
-from dotenv import load_dotenv
 
 import discord
 from discord import app_commands
 from discord.ext import commands
 import gv
 
-load_dotenv()
 
 class Hagakure_Select(discord.ui.Select):
     def __init__(self,options:list[discord.SelectOption]):
@@ -53,5 +51,5 @@ class Hagakure(commands.Cog):#コマンド名、頭大文字でクラス作成
 async def setup(bot:commands.Bot):
     await bot.add_cog(
         Hagakure(bot),
-        guilds = [discord.Object(id=os.getenv("GUILD_ID"))]
+        guilds = [discord.Object(id=bot.useGuildId)]
         )

--- a/cogs/ItemEffectRegistration.py
+++ b/cogs/ItemEffectRegistration.py
@@ -1,5 +1,4 @@
 import os 
-from dotenv import load_dotenv
 
 from typing import List, Literal
 
@@ -10,7 +9,6 @@ from discord.ext import commands
 
 import gv
 
-load_dotenv()
 
 class ItemEffectRegistration(commands.Cog):#Cog名、任意だが分かりやすさのためにコマンドが一つなら頭大文字でクラス作成
     def __init__(self, bot:commands.Bot):
@@ -32,5 +30,5 @@ class ItemEffectRegistration(commands.Cog):#Cog名、任意だが分かりやす
 async def setup(bot:commands.Bot):
     await bot.add_cog(
         ItemEffectRegistration(bot),
-        guilds = [discord.Object(id=os.getenv("GUILD_ID"))]
+        guilds = [discord.Object(id=bot.useGuildId)]
         )

--- a/cogs/KillrianCamera.py
+++ b/cogs/KillrianCamera.py
@@ -1,5 +1,4 @@
 import os
-from dotenv import load_dotenv
 
 import discord
 from discord import app_commands
@@ -10,7 +9,6 @@ from typing import List
 
 import gv
 
-load_dotenv()
 
 class KillrianCamera_Select(discord.ui.Select):
     def __init__(self,options:list[discord.SelectOption]):
@@ -52,5 +50,5 @@ class KillrianCamera(commands.Cog):#コマンド名、頭大文字でクラス�
 async def setup(bot:commands.Bot):
     await bot.add_cog(
         KillrianCamera(bot),
-        guilds = [discord.Object(id=os.getenv("GUILD_ID"))]
+        guilds = [discord.Object(id=bot.useGuildId)]
         )

--- a/cogs/Kirigiri_ability.py
+++ b/cogs/Kirigiri_ability.py
@@ -1,13 +1,11 @@
 import os 
 import discord.context_managers
-from dotenv import load_dotenv
 
 import discord
 from discord import app_commands
 from discord.ext import commands
 import gv
 
-load_dotenv()
 
 class Kirigiri_Select(discord.ui.Select):
     def __init__(self,options:list[discord.SelectOption]):
@@ -69,5 +67,5 @@ class Kirigiri(commands.Cog):#コマンド名、頭大文字でクラス作成
 async def setup(bot:commands.Bot):
     await bot.add_cog(
         Kirigiri(bot),
-        guilds = [discord.Object(id=os.getenv("GUILD_ID"))]
+        guilds = [discord.Object(id=bot.useGuildId)]
         )

--- a/cogs/Megane.py
+++ b/cogs/Megane.py
@@ -1,13 +1,11 @@
 import os 
 import discord.context_managers
-from dotenv import load_dotenv
 
 import discord
 from discord import app_commands
 from discord.ext import commands
 import gv
 
-load_dotenv()
 
 class Megane_Select(discord.ui.Select):
     def __init__(self,options:list[discord.SelectOption]):
@@ -69,5 +67,5 @@ class Megane(commands.Cog):#コマンド名、頭大文字でクラス作成
 async def setup(bot:commands.Bot):
     await bot.add_cog(
         Megane(bot),
-        guilds = [discord.Object(id=os.getenv("GUILD_ID"))]
+        guilds = [discord.Object(id=bot.useGuildId)]
         )

--- a/cogs/Night.py
+++ b/cogs/Night.py
@@ -1,5 +1,4 @@
 import os
-from dotenv import load_dotenv
 
 import discord
 from discord import app_commands
@@ -10,7 +9,6 @@ from typing import List
 
 import gv
 
-load_dotenv()
 
 #対象のセレクトメニュー及び朝時間開始時の処理
 class Night_Select(discord.ui.Select):#1人選んでそれぞれの能力の対象にするため使用者で分岐させる
@@ -149,5 +147,5 @@ class Night(commands.Cog):
 async def setup(bot:commands.Bot):
     await bot.add_cog(
         Night(bot),
-        guilds = [discord.Object(id=os.getenv("GUILD_ID"))]
+        guilds = [discord.Object(id=bot.useGuildId)]
         )

--- a/cogs/Rehearsal.py
+++ b/cogs/Rehearsal.py
@@ -1,5 +1,4 @@
 import os
-from dotenv import load_dotenv
 
 import discord
 from discord import app_commands
@@ -10,7 +9,6 @@ from typing import List
 
 import gv
 
-load_dotenv()
 
 class Rehearsal_Select(discord.ui.Select):
     def __init__(self,options:list[discord.SelectOption]):
@@ -57,5 +55,5 @@ class Rehearsal(commands.Cog):#コマンド名、頭大文字でクラス作成
 async def setup(bot:commands.Bot):
     await bot.add_cog(
         Rehearsal(bot),
-        guilds = [discord.Object(id=os.getenv("GUILD_ID"))]
+        guilds = [discord.Object(id=bot.useGuildId)]
         )

--- a/cogs/SilentPhone.py
+++ b/cogs/SilentPhone.py
@@ -1,13 +1,11 @@
 import os 
 import discord.context_managers
-from dotenv import load_dotenv
 
 import discord
 from discord import app_commands
 from discord.ext import commands
 import gv
 
-load_dotenv()
 
 class SilentPhone_Select(discord.ui.Select):
     def __init__(self,options:list[discord.SelectOption]):
@@ -52,5 +50,5 @@ class SilentPhone(commands.Cog):#コマンド名、頭大文字でクラス作�
 async def setup(bot:commands.Bot):
     await bot.add_cog(
         SilentPhone(bot),
-        guilds = [discord.Object(id=os.getenv("GUILD_ID"))]
+        guilds = [discord.Object(id=bot.useGuildId)]
         )

--- a/cogs/Tsumiki.py
+++ b/cogs/Tsumiki.py
@@ -1,5 +1,4 @@
 import os
-from dotenv import load_dotenv
 
 import discord
 from discord import app_commands
@@ -10,7 +9,6 @@ from typing import List
 
 import gv
 
-load_dotenv()
 
 class Tsumiki_Select(discord.ui.Select):
     def __init__(self,options:list[discord.SelectOption]):
@@ -52,5 +50,5 @@ class Tsumiki(commands.Cog):#コマンド名、頭大文字でクラス作成
 async def setup(bot:commands.Bot):
     await bot.add_cog(
         Tsumiki(bot),
-        guilds = [discord.Object(id=os.getenv("GUILD_ID"))]
+        guilds = [discord.Object(id=bot.useGuildId)]
         )

--- a/cogs/Yasuke.py
+++ b/cogs/Yasuke.py
@@ -1,12 +1,10 @@
 import os 
 import discord.context_managers
-from dotenv import load_dotenv
 
 import discord
 from discord import app_commands
 from discord.ext import commands
 
-load_dotenv()
 
 # 全ロール剥奪（松田夜助）
 class Yasuke(commands.Cog):#コマンド名、頭大文字でクラス作成
@@ -32,5 +30,5 @@ class Yasuke(commands.Cog):#コマンド名、頭大文字でクラス作成
 async def setup(bot:commands.Bot):
     await bot.add_cog(
         Yasuke(bot),
-        guilds = [discord.Object(id=os.getenv("GUILD_ID"))]
+        guilds = [discord.Object(id=bot.useGuildId)]
         )

--- a/cogs/cog_temp
+++ b/cogs/cog_temp
@@ -1,12 +1,10 @@
 import os 
 import discord.context_managers
-from dotenv import load_dotenv
 
 import discord
 from discord import app_commands
 from discord.ext import commands
 
-load_dotenv()
 
 class Cog名(commands.Cog):#Cog名、任意だが分かりやすさのためにコマンドが一つなら頭大文字でクラス作成
     def __init__(self, bot:commands.Bot):
@@ -22,5 +20,5 @@ class Cog名(commands.Cog):#Cog名、任意だが分かりやすさのために�
 async def setup(bot:commands.Bot):
     await bot.add_cog(
         Cog名(bot),
-        guilds = [discord.Object(id=os.getenv("GUILD_ID"))]
+        guilds = [discord.Object(id=bot.useGuildId)]
         )

--- a/cogs/ext_test.py
+++ b/cogs/ext_test.py
@@ -1,12 +1,10 @@
 import os 
 import discord.context_managers
-from dotenv import load_dotenv
 
 import discord
 from discord import app_commands
 from discord.ext import commands
 
-load_dotenv()
 
 class Ext_test(commands.Cog):
     def __init__(self, bot:commands.Bot):
@@ -22,5 +20,5 @@ class Ext_test(commands.Cog):
 async def setup(bot:commands.Bot):
     await bot.add_cog(
         Ext_test(bot),
-        guilds = [discord.Object(id=os.getenv("GUILD_ID"))]
+        guilds = [discord.Object(id=bot.useGuildId)]
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+# “®ì‚Éƒ‰ƒCƒuƒ‰ƒŠ
+discord
+discord-ext-ui
+python-dotenv


### PR DESCRIPTION
*  トークン・サーバーIDを.env経由でしか入力できなかったのを`-tokenId=` `-guildId=` などのコマンドラインオプションから指定できるように調整
*  .envなどの追加・コミットをしたら困るファイルを無視設定
*  batをダブルクリックするだけでpythonの動作に必要なパッケージがpip installされるように調整